### PR TITLE
Add hover effect to cards

### DIFF
--- a/app/assets/stylesheets/components/_card.scss
+++ b/app/assets/stylesheets/components/_card.scss
@@ -15,6 +15,11 @@
   height: 250px;
   background-size: cover !important;
   background-position: center;
+  opacity: 0.8;
+  transition: all 0.25s ease;
+  &:hover {
+    opacity: 1;
+  }
 }
 .card .body {
   padding: 10px;


### PR DESCRIPTION
Added a hover effect on the main cards page. When user hovers over the card image, it now lights up. This also means that we could potentially remove that faded effect from the default picture that gets uploaded when a user doesn't provide a picture.